### PR TITLE
Fix local image loading on worklist view

### DIFF
--- a/templates/dicom_viewer/base.html
+++ b/templates/dicom_viewer/base.html
@@ -2213,9 +2213,228 @@
             fileInput.addEventListener('change', function(e) {
                 const files = Array.from(e.target.files);
                 if (files.length > 0) {
-                    processDicomFiles(files);
+                    // Check if we can process locally or need to upload
+                    if (typeof dicomParser !== 'undefined' && files.length <= 50) {
+                        processLocalDicomFiles(files);
+                    } else {
+                        processDicomFiles(files);
+                    }
                 }
             });
+        }
+        
+        // Enhanced local DICOM file processing (same as in viewer.html)
+        async function processLocalDicomFiles(files) {
+            if (!files || files.length === 0) return;
+            
+            try {
+                showLoading('Processing local DICOM files...');
+                
+                // Check if dicomParser is available
+                if (typeof dicomParser === 'undefined') {
+                    showToast('DICOM parser not available - uploading to server instead', 'info');
+                    return processDicomFiles(files);
+                }
+                
+                // Filter for DICOM files
+                const dicomFiles = Array.from(files).filter(f => {
+                    const name = (f.name || '').toLowerCase();
+                    return name.endsWith('.dcm') || name.endsWith('.dicom') || f.size > 132;
+                });
+                
+                if (dicomFiles.length === 0) {
+                    hideLoading();
+                    showToast('No DICOM files found in selection', 'warning');
+                    return;
+                }
+                
+                // Process files locally for small datasets
+                const localImages = [];
+                let processedCount = 0;
+                
+                for (const file of dicomFiles) {
+                    try {
+                        const buffer = await file.arrayBuffer();
+                        const byteArray = new Uint8Array(buffer);
+                        const dataSet = dicomParser.parseDicom(byteArray);
+                        
+                        // Extract image information
+                        const rows = dataSet.uint16('x00280010') || 0;
+                        const cols = dataSet.uint16('x00280011') || 0;
+                        const bitsAllocated = dataSet.uint16('x00280100') || 16;
+                        const pixelRepresentation = dataSet.uint16('x00280103') || 0;
+                        const samplesPerPixel = dataSet.uint16('x00280002') || 1;
+                        
+                        // Only handle grayscale images for now
+                        if (samplesPerPixel !== 1 || !rows || !cols) continue;
+                        
+                        const pixelDataElement = dataSet.elements.x7fe00010;
+                        if (!pixelDataElement) continue;
+                        
+                        const pixelData = new Uint8Array(
+                            dataSet.byteArray.buffer, 
+                            pixelDataElement.dataOffset, 
+                            pixelDataElement.length
+                        );
+                        
+                        // Convert pixel data to Float32Array
+                        let pixels;
+                        if (bitsAllocated === 8) {
+                            pixels = new Float32Array(pixelData);
+                        } else if (bitsAllocated === 16) {
+                            const view = new DataView(pixelData.buffer, pixelData.byteOffset, pixelData.byteLength);
+                            const pixelCount = pixelData.byteLength / 2;
+                            pixels = new Float32Array(pixelCount);
+                            
+                            for (let i = 0; i < pixelCount; i++) {
+                                pixels[i] = pixelRepresentation === 1 
+                                    ? view.getInt16(i * 2, true) 
+                                    : view.getUint16(i * 2, true);
+                            }
+                        } else {
+                            continue;
+                        }
+                        
+                        // Extract window/level values
+                        let windowWidth = dataSet.floatString('x00281051') || null;
+                        let windowLevel = dataSet.floatString('x00281050') || null;
+                        
+                        // Calculate automatic window/level if not provided
+                        if (!windowWidth || !windowLevel) {
+                            let min = Infinity, max = -Infinity;
+                            for (let i = 0; i < pixels.length; i++) {
+                                const val = pixels[i];
+                                if (val < min) min = val;
+                                if (val > max) max = val;
+                            }
+                            windowWidth = Math.max(1, max - min);
+                            windowLevel = Math.round(min + windowWidth / 2);
+                        }
+                        
+                        localImages.push({
+                            rows,
+                            cols,
+                            pixels,
+                            windowWidth: parseFloat(windowWidth),
+                            windowLevel: parseFloat(windowLevel),
+                            filename: file.name
+                        });
+                        
+                        processedCount++;
+                        
+                    } catch (parseError) {
+                        console.warn(`Failed to parse ${file.name}:`, parseError);
+                        continue;
+                    }
+                }
+                
+                if (localImages.length === 0) {
+                    hideLoading();
+                    showToast('No valid DICOM images could be processed', 'error');
+                    return;
+                }
+                
+                // Set up local image viewer
+                await setupLocalImageViewer(localImages);
+                hideLoading();
+                showToast(`Successfully loaded ${localImages.length} local DICOM images`, 'success');
+                
+            } catch (error) {
+                hideLoading();
+                console.error('Error processing local DICOM files:', error);
+                showToast('Error processing local files - uploading to server instead', 'warning');
+                return processDicomFiles(files);
+            }
+        }
+        
+        // Setup local image viewer
+        async function setupLocalImageViewer(localImages) {
+            // Set up global variables
+            images = localImages.map((img, index) => ({ 
+                id: `local_${index}`, 
+                instance_number: index + 1,
+                local_data: img 
+            }));
+            currentImageIndex = 0;
+            currentSeries = { 
+                series_description: 'Local DICOM Files',
+                modality: 'LOCAL'
+            };
+            currentStudy = {
+                patient_name: 'Local Files',
+                accession_number: 'LOCAL'
+            };
+            
+            // Update UI
+            document.getElementById('studyStatus').textContent = 'Local DICOM Files';
+            document.getElementById('seriesStatus').textContent = `Local Files (${localImages.length} images)`;
+            document.getElementById('imageCount').textContent = localImages.length;
+            
+            // Setup slice slider
+            const sliceSlider = document.getElementById('sliceSlider');
+            if (sliceSlider) {
+                sliceSlider.max = Math.max(0, localImages.length - 1);
+                sliceSlider.value = 0;
+            }
+            
+            // Render first image
+            await renderLocalImage(0);
+        }
+        
+        // Render local image to canvas
+        async function renderLocalImage(index) {
+            if (!images[index] || !images[index].local_data) return;
+            
+            const imageData = images[index].local_data;
+            const canvas = document.getElementById('dicomCanvas');
+            const img = document.getElementById('dicomImage');
+            
+            if (!canvas) return;
+            
+            const ctx = canvas.getContext('2d');
+            
+            // Set canvas dimensions
+            canvas.width = imageData.cols;
+            canvas.height = imageData.rows;
+            
+            // Create image data
+            const canvasImageData = ctx.createImageData(imageData.cols, imageData.rows);
+            
+            // Apply window/level
+            const ww = windowWidth || imageData.windowWidth;
+            const wl = windowLevel || imageData.windowLevel;
+            const lowValue = wl - ww / 2;
+            const highValue = wl + ww / 2;
+            const range = highValue - lowValue;
+            
+            for (let i = 0; i < imageData.pixels.length; i++) {
+                const pixelValue = imageData.pixels[i];
+                let displayValue = ((pixelValue - lowValue) / range) * 255;
+                
+                // Clamp to 0-255
+                displayValue = Math.max(0, Math.min(255, displayValue));
+                
+                // Apply inversion if needed
+                if (inverted) {
+                    displayValue = 255 - displayValue;
+                }
+                
+                const byteIndex = i * 4;
+                canvasImageData.data[byteIndex] = displayValue;
+                canvasImageData.data[byteIndex + 1] = displayValue;
+                canvasImageData.data[byteIndex + 2] = displayValue;
+                canvasImageData.data[byteIndex + 3] = 255;
+            }
+            
+            // Draw to canvas
+            ctx.putImageData(canvasImageData, 0, 0);
+            
+            // Update slice info
+            currentImageIndex = index;
+            
+            // Hide the img element and show canvas
+            if (img) img.style.display = 'none';
+            canvas.style.display = 'block';
         }
 
         // Optimized Tool Management - Fast Response
@@ -2435,7 +2654,13 @@
         function updateSlice(value) {
             currentImageIndex = parseInt(value);
             document.getElementById('sliceValue').textContent = `${currentImageIndex + 1}/${images.length}`;
-            updateImageDisplay();
+            
+            // Check if this is a local image
+            if (images[currentImageIndex] && images[currentImageIndex].local_data) {
+                renderLocalImage(currentImageIndex);
+            } else {
+                updateImageDisplay();
+            }
         }
 
         function changeSlice(direction) {
@@ -2444,7 +2669,13 @@
                 currentImageIndex = newIndex;
                 document.getElementById('sliceSlider').value = currentImageIndex;
                 document.getElementById('sliceValue').textContent = `${currentImageIndex + 1}/${images.length}`;
-                updateImageDisplay();
+                
+                // Check if this is a local image
+                if (images[currentImageIndex] && images[currentImageIndex].local_data) {
+                    renderLocalImage(currentImageIndex);
+                } else {
+                    updateImageDisplay();
+                }
             }
         }
 
@@ -2481,7 +2712,18 @@
                         }
                         
                         // Render to high-quality canvas with modality-specific optimization
-                        renderImageToCanvas(dicomImage, dicomCanvas, modality);
+                        try {
+                            renderImageToCanvas(dicomImage, dicomCanvas, modality);
+                            // Hide the img element and show canvas
+                            dicomImage.style.display = 'none';
+                            dicomCanvas.style.display = 'block';
+                            console.log('Image rendered to canvas successfully');
+                        } catch (canvasError) {
+                            console.warn('Canvas rendering failed, using image element:', canvasError);
+                            // Fallback to showing the image element
+                            dicomCanvas.style.display = 'none';
+                            dicomImage.style.display = 'block';
+                        }
                         
                         // Reapply any active transformations
                         if (flipHorizontalState || flipVerticalState || rotationAngle !== 0) {
@@ -4784,5 +5026,8 @@
             }
         });
     </script>
+    
+    <!-- DICOM Parser Library -->
+    <script src="{% static 'js/vendor/dicomParser.min.js' %}"></script>
 </body>
 </html>

--- a/templates/dicom_viewer/viewer.html
+++ b/templates/dicom_viewer/viewer.html
@@ -1557,7 +1557,7 @@
             fileInput.addEventListener('change', function(e) {
                 const files = Array.from(e.target.files);
                 if (files.length > 0) {
-                    processDicomFiles(files);
+                    processLocalDicomFiles(files);
                 }
             });
         }
@@ -1687,7 +1687,13 @@
                 // Handle regular image navigation
                 currentImageIndex = parseInt(value);
                 document.getElementById('sliceValue').textContent = `${currentImageIndex + 1}/${images.length}`;
-                updateImageDisplay();
+                
+                // Check if this is a local image
+                if (images[currentImageIndex] && images[currentImageIndex].local_data) {
+                    renderLocalImage(currentImageIndex);
+                } else {
+                    updateImageDisplay();
+                }
             }
         }
 
@@ -1752,10 +1758,6 @@
                     // Set up successful load handler
                     dicomImage.onload = function() {
                         console.log('DICOM image loaded successfully');
-                        hideLoading();
-                        updateImageInfo(data.image_info);
-                        updateMeasurementOverlay();
-                        updateAnnotationOverlay();
                         
                         // Apply high-quality rendering for medical images
                         dicomImage.style.imageRendering = 'pixelated';
@@ -1767,6 +1769,33 @@
                         // Ensure the image is visible
                         dicomImage.style.display = 'block';
                         dicomImage.style.visibility = 'visible';
+                        
+                        // Render to canvas for better control and quality
+                        const canvas = document.getElementById('dicomCanvas');
+                        if (canvas && dicomImage.complete && dicomImage.naturalWidth > 0) {
+                            try {
+                                renderImageToCanvas(dicomImage, canvas, currentSeries?.modality);
+                                // Hide the img element and show canvas
+                                dicomImage.style.display = 'none';
+                                canvas.style.display = 'block';
+                                console.log('Image rendered to canvas successfully');
+                            } catch (canvasError) {
+                                console.warn('Canvas rendering failed, using image element:', canvasError);
+                                // Fallback to showing the image element
+                                canvas.style.display = 'none';
+                                dicomImage.style.display = 'block';
+                            }
+                        } else {
+                            // Fallback to image element if canvas not available
+                            const canvas = document.getElementById('dicomCanvas');
+                            if (canvas) canvas.style.display = 'none';
+                            dicomImage.style.display = 'block';
+                        }
+                        
+                        hideLoading();
+                        updateImageInfo(data.image_info);
+                        updateMeasurementOverlay();
+                        updateAnnotationOverlay();
                         
                         showToast('DICOM image loaded successfully', 'success');
                     };
@@ -2060,6 +2089,380 @@
                 console.error('Error opening file browser:', e);
                 showToast('File browser opened', 'success');
             }
+        }
+
+        // Enhanced local DICOM file processing with direct canvas rendering
+        async function processLocalDicomFiles(files) {
+            if (!files || files.length === 0) return;
+            
+            try {
+                showLoading('Processing local DICOM files...');
+                
+                // Check if dicomParser is available
+                if (typeof dicomParser === 'undefined') {
+                    showToast('DICOM parser not available - uploading to server instead', 'info');
+                    return processDicomFiles(files);
+                }
+                
+                // Filter for DICOM files
+                const dicomFiles = Array.from(files).filter(f => {
+                    const name = (f.name || '').toLowerCase();
+                    return name.endsWith('.dcm') || name.endsWith('.dicom') || f.size > 132;
+                });
+                
+                if (dicomFiles.length === 0) {
+                    hideLoading();
+                    showToast('No DICOM files found in selection', 'warning');
+                    return;
+                }
+                
+                // Sort files naturally
+                dicomFiles.sort((a, b) => {
+                    const aPath = a.webkitRelativePath || a.name;
+                    const bPath = b.webkitRelativePath || b.name;
+                    return aPath.localeCompare(bPath, undefined, { numeric: true });
+                });
+                
+                // If too many files, upload to server for better handling
+                if (dicomFiles.length > 50) {
+                    showToast(`Large dataset (${dicomFiles.length} files) - uploading to server for optimal processing`, 'info');
+                    return processDicomFiles(dicomFiles);
+                }
+                
+                // Process files locally
+                const localImages = [];
+                let processedCount = 0;
+                
+                for (const file of dicomFiles) {
+                    try {
+                        const buffer = await file.arrayBuffer();
+                        const byteArray = new Uint8Array(buffer);
+                        const dataSet = dicomParser.parseDicom(byteArray);
+                        
+                        // Extract image information
+                        const rows = dataSet.uint16('x00280010') || 0;
+                        const cols = dataSet.uint16('x00280011') || 0;
+                        const bitsAllocated = dataSet.uint16('x00280100') || 16;
+                        const pixelRepresentation = dataSet.uint16('x00280103') || 0;
+                        const samplesPerPixel = dataSet.uint16('x00280002') || 1;
+                        
+                        // Only handle grayscale images for now
+                        if (samplesPerPixel !== 1 || !rows || !cols) continue;
+                        
+                        const pixelDataElement = dataSet.elements.x7fe00010;
+                        if (!pixelDataElement) continue;
+                        
+                        const pixelData = new Uint8Array(
+                            dataSet.byteArray.buffer, 
+                            pixelDataElement.dataOffset, 
+                            pixelDataElement.length
+                        );
+                        
+                        // Convert pixel data to Float32Array
+                        let pixels;
+                        if (bitsAllocated === 8) {
+                            pixels = new Float32Array(pixelData);
+                        } else if (bitsAllocated === 16) {
+                            const view = new DataView(pixelData.buffer, pixelData.byteOffset, pixelData.byteLength);
+                            const pixelCount = pixelData.byteLength / 2;
+                            pixels = new Float32Array(pixelCount);
+                            
+                            for (let i = 0; i < pixelCount; i++) {
+                                pixels[i] = pixelRepresentation === 1 
+                                    ? view.getInt16(i * 2, true) 
+                                    : view.getUint16(i * 2, true);
+                            }
+                        } else {
+                            continue; // Skip unsupported bit depths
+                        }
+                        
+                        // Extract window/level values
+                        let windowWidth = dataSet.floatString('x00281051') || null;
+                        let windowLevel = dataSet.floatString('x00281050') || null;
+                        
+                        // Calculate automatic window/level if not provided
+                        if (!windowWidth || !windowLevel) {
+                            let min = Infinity, max = -Infinity;
+                            for (let i = 0; i < pixels.length; i++) {
+                                const val = pixels[i];
+                                if (val < min) min = val;
+                                if (val > max) max = val;
+                            }
+                            windowWidth = Math.max(1, max - min);
+                            windowLevel = Math.round(min + windowWidth / 2);
+                        }
+                        
+                        localImages.push({
+                            rows,
+                            cols,
+                            pixels,
+                            windowWidth: parseFloat(windowWidth),
+                            windowLevel: parseFloat(windowLevel),
+                            filename: file.name
+                        });
+                        
+                        processedCount++;
+                        
+                        // Update progress
+                        if (processedCount % 10 === 0) {
+                            showToast(`Processed ${processedCount}/${dicomFiles.length} files...`, 'info', 1000);
+                        }
+                        
+                    } catch (parseError) {
+                        console.warn(`Failed to parse ${file.name}:`, parseError);
+                        continue;
+                    }
+                }
+                
+                if (localImages.length === 0) {
+                    hideLoading();
+                    showToast('No valid DICOM images could be processed', 'error');
+                    return;
+                }
+                
+                // Set up local image viewer
+                await setupLocalImageViewer(localImages);
+                hideLoading();
+                showToast(`Successfully loaded ${localImages.length} local DICOM images`, 'success');
+                
+            } catch (error) {
+                hideLoading();
+                console.error('Error processing local DICOM files:', error);
+                showToast('Error processing local files - uploading to server instead', 'warning');
+                return processDicomFiles(files);
+            }
+        }
+        
+        // Setup local image viewer with canvas rendering
+        async function setupLocalImageViewer(localImages) {
+            // Hide welcome screen and show image view
+            const welcomeScreen = document.getElementById('welcomeScreen');
+            const singleView = document.getElementById('singleView');
+            if (welcomeScreen) welcomeScreen.style.display = 'none';
+            if (singleView) singleView.style.display = 'flex';
+            
+            // Set up global variables
+            images = localImages.map((img, index) => ({ 
+                id: `local_${index}`, 
+                instance_number: index + 1,
+                local_data: img 
+            }));
+            currentImageIndex = 0;
+            currentSeries = { 
+                series_description: 'Local DICOM Files',
+                modality: 'LOCAL'
+            };
+            currentStudy = {
+                patient_name: 'Local Files',
+                accession_number: 'LOCAL'
+            };
+            
+            // Update UI
+            document.getElementById('studyStatus').textContent = 'Local DICOM Files';
+            document.getElementById('seriesStatus').textContent = `Local Files (${localImages.length} images)`;
+            document.getElementById('imageCount').textContent = localImages.length;
+            
+            // Setup slice slider
+            const sliceSlider = document.getElementById('sliceSlider');
+            sliceSlider.max = Math.max(0, localImages.length - 1);
+            sliceSlider.value = 0;
+            
+            // Update series info
+            document.getElementById('seriesInfo').innerHTML = `
+                <div>Images: ${localImages.length}</div>
+                <div>Modality: LOCAL</div>
+                <div>Source: Local Files</div>
+            `;
+            
+            // Render first image
+            await renderLocalImage(0);
+            
+            // Set up navigation
+            setupLocalImageNavigation();
+        }
+        
+        // Render local image to canvas
+        async function renderLocalImage(index) {
+            if (!images[index] || !images[index].local_data) return;
+            
+            const imageData = images[index].local_data;
+            const canvas = document.getElementById('dicomCanvas');
+            const img = document.getElementById('dicomImage');
+            
+            if (!canvas) return;
+            
+            const ctx = canvas.getContext('2d');
+            
+            // Set canvas dimensions
+            canvas.width = imageData.cols;
+            canvas.height = imageData.rows;
+            
+            // Create image data
+            const canvasImageData = ctx.createImageData(imageData.cols, imageData.rows);
+            
+            // Apply window/level
+            const ww = windowWidth || imageData.windowWidth;
+            const wl = windowLevel || imageData.windowLevel;
+            const lowValue = wl - ww / 2;
+            const highValue = wl + ww / 2;
+            const range = highValue - lowValue;
+            
+            for (let i = 0; i < imageData.pixels.length; i++) {
+                const pixelValue = imageData.pixels[i];
+                let displayValue = ((pixelValue - lowValue) / range) * 255;
+                
+                // Clamp to 0-255
+                displayValue = Math.max(0, Math.min(255, displayValue));
+                
+                // Apply inversion if needed
+                if (inverted) {
+                    displayValue = 255 - displayValue;
+                }
+                
+                const byteIndex = i * 4;
+                canvasImageData.data[byteIndex] = displayValue;     // Red
+                canvasImageData.data[byteIndex + 1] = displayValue; // Green
+                canvasImageData.data[byteIndex + 2] = displayValue; // Blue
+                canvasImageData.data[byteIndex + 3] = 255;          // Alpha
+            }
+            
+            // Draw to canvas
+            ctx.putImageData(canvasImageData, 0, 0);
+            
+            // Update image info
+            updateImageInfo({
+                rows: imageData.rows,
+                cols: imageData.cols,
+                window_width: ww,
+                window_level: wl,
+                filename: imageData.filename
+            });
+            
+            // Update slice info
+            document.getElementById('sliceValue').textContent = `${index + 1}/${images.length}`;
+            currentImageIndex = index;
+            
+            // Hide the img element and show canvas
+            if (img) img.style.display = 'none';
+            canvas.style.display = 'block';
+        }
+        
+        // Setup navigation for local images
+        function setupLocalImageNavigation() {
+            const canvas = document.getElementById('dicomCanvas');
+            if (!canvas) return;
+            
+            // Mouse wheel navigation
+            canvas.addEventListener('wheel', (e) => {
+                e.preventDefault();
+                const delta = e.deltaY > 0 ? 1 : -1;
+                const newIndex = Math.max(0, Math.min(images.length - 1, currentImageIndex + delta));
+                if (newIndex !== currentImageIndex) {
+                    renderLocalImage(newIndex);
+                    document.getElementById('sliceSlider').value = newIndex;
+                }
+            }, { passive: false });
+            
+            // Keyboard navigation
+            document.addEventListener('keydown', (e) => {
+                if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+                
+                let newIndex = currentImageIndex;
+                if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+                    e.preventDefault();
+                    newIndex = Math.max(0, currentImageIndex - 1);
+                } else if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+                    e.preventDefault();
+                    newIndex = Math.min(images.length - 1, currentImageIndex + 1);
+                }
+                
+                if (newIndex !== currentImageIndex) {
+                    renderLocalImage(newIndex);
+                    document.getElementById('sliceSlider').value = newIndex;
+                }
+            });
+        }
+
+        // Enhanced High-Quality Canvas Rendering Function for Medical Images
+        function renderImageToCanvas(imgElement, canvas, modality) {
+            if (!imgElement || !canvas || !imgElement.complete) return;
+            
+            const ctx = canvas.getContext('2d');
+            
+            // Get device pixel ratio for high-DPI displays
+            const dpr = window.devicePixelRatio || 1;
+            
+            // Get display size
+            const rect = canvas.getBoundingClientRect();
+            const displayWidth = rect.width;
+            const displayHeight = rect.height;
+            
+            // Modality-specific resolution enhancement
+            let resolutionMultiplier = 1.5; // Default for CT/MR
+            if (modality && ['DX', 'CR', 'DR', 'XA', 'RF'].includes(modality.toUpperCase())) {
+                resolutionMultiplier = 2.0; // Higher resolution for X-ray images
+            }
+            
+            // Set actual canvas size to device pixel ratio with enhanced resolution
+            canvas.width = displayWidth * dpr * resolutionMultiplier;
+            canvas.height = displayHeight * dpr * resolutionMultiplier;
+            
+            // Scale canvas back down using CSS
+            canvas.style.width = displayWidth + 'px';
+            canvas.style.height = displayHeight + 'px';
+            
+            // Scale the drawing context to match enhanced pixel ratio
+            ctx.scale(dpr * resolutionMultiplier, dpr * resolutionMultiplier);
+            
+            // Enable highest quality rendering for medical images
+            ctx.imageSmoothingEnabled = true;
+            ctx.imageSmoothingQuality = 'high';
+            
+            // Modality-specific rendering optimizations
+            if (modality && ['DX', 'CR', 'DR', 'XA', 'RF'].includes(modality.toUpperCase())) {
+                // For X-ray images, disable smoothing to preserve sharp edges
+                ctx.imageSmoothingEnabled = false;
+                ctx.filter = 'contrast(1.1) brightness(1.05)'; // Slight enhancement for X-rays
+            } else {
+                // Additional quality settings for CT/MR imaging
+                ctx.textRenderingOptimization = 'optimizeQuality';
+                ctx.filter = 'none'; // Disable any default filters that might degrade image quality
+            }
+            
+            // Calculate aspect-preserving dimensions
+            const imgAspect = imgElement.naturalWidth / imgElement.naturalHeight;
+            const canvasAspect = displayWidth / displayHeight;
+            
+            let drawWidth, drawHeight, drawX, drawY;
+            
+            if (imgAspect > canvasAspect) {
+                // Image is wider than canvas
+                drawWidth = displayWidth;
+                drawHeight = displayWidth / imgAspect;
+                drawX = 0;
+                drawY = (displayHeight - drawHeight) / 2;
+            } else {
+                // Image is taller than canvas
+                drawWidth = displayHeight * imgAspect;
+                drawHeight = displayHeight;
+                drawX = (displayWidth - drawWidth) / 2;
+                drawY = 0;
+            }
+            
+            // Apply current zoom and pan transformations
+            ctx.save();
+            ctx.translate(displayWidth / 2, displayHeight / 2);
+            ctx.scale(zoomFactor, zoomFactor);
+            ctx.translate(-displayWidth / 2 + panX / zoomFactor, -displayHeight / 2 + panY / zoomFactor);
+            
+            // Clear canvas with black background
+            ctx.fillStyle = '#000000';
+            ctx.fillRect(-displayWidth, -displayHeight, displayWidth * 3, displayHeight * 3);
+            
+            // Draw image with high-quality interpolation
+            ctx.drawImage(imgElement, drawX, drawY, drawWidth, drawHeight);
+            
+            ctx.restore();
         }
 
         function loadFromExternalMedia() {
@@ -4112,6 +4515,9 @@
             setTimeout(initializeDropdowns, 100);
         });
     </script>
+    
+    <!-- DICOM Parser Library -->
+    <script src="{% static 'js/vendor/dicomParser.min.js' %}"></script>
     
     <!-- Professional Keyboard Shortcuts - Safe Enhancement -->
     <script src="{% load static %}{% static 'js/dicom-viewer-keyboard-shortcuts.js' %}"></script>


### PR DESCRIPTION
Implement client-side DICOM local file loading and fix canvas image display for both local and server-loaded studies.

The previous "Load Local" function only opened a file dialog without processing files, and the "VIEW" button from the worklist failed to render images to the canvas. This PR introduces client-side DICOM parsing and ensures all images are correctly displayed and navigable on the canvas.

---
<a href="https://cursor.com/background-agent?bcId=bc-58799edf-cdd2-41e2-b0a0-1a58d621d8ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-58799edf-cdd2-41e2-b0a0-1a58d621d8ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

