### PR TITLE
Fix dicom viewer errors and recursion

### DIFF
--- a/static/js/dicom-viewer-fixes.js
+++ b/static/js/dicom-viewer-fixes.js
@@ -203,9 +203,17 @@ function fixCanvasEventHandlers() {
         } else {
             // Scroll through images
             if (e.deltaY > 0) {
-                nextImage();
+                if (typeof navigateImage === 'function') {
+                    navigateImage(1);
+                } else if (typeof window.navigateImage === 'function') {
+                    window.navigateImage(1);
+                }
             } else {
-                previousImage();
+                if (typeof navigateImage === 'function') {
+                    navigateImage(-1);
+                } else if (typeof window.navigateImage === 'function') {
+                    window.navigateImage(-1);
+                }
             }
         }
     });

--- a/staticfiles/js/dicom-viewer-fixes.js
+++ b/staticfiles/js/dicom-viewer-fixes.js
@@ -203,9 +203,17 @@ function fixCanvasEventHandlers() {
         } else {
             // Scroll through images
             if (e.deltaY > 0) {
-                nextImage();
+                if (typeof navigateImage === 'function') {
+                    navigateImage(1);
+                } else if (typeof window.navigateImage === 'function') {
+                    window.navigateImage(1);
+                }
             } else {
-                previousImage();
+                if (typeof navigateImage === 'function') {
+                    navigateImage(-1);
+                } else if (typeof window.navigateImage === 'function') {
+                    window.navigateImage(-1);
+                }
             }
         }
     });

--- a/templates/dicom_viewer/masterpiece_viewer.html
+++ b/templates/dicom_viewer/masterpiece_viewer.html
@@ -3419,8 +3419,22 @@
 
         // Helper functions
         function showLoading(message) {
-            if (typeof window.showLoading === 'function') {
-                window.showLoading(message);
+            // Look for the main showLoading function in the parent document or other scope
+            const mainShowLoading = window.parent?.showLoading || 
+                                  document.querySelector('script')?.showLoading ||
+                                  (() => {
+                                      const overlay = document.getElementById('loadingOverlay');
+                                      const messageEl = document.getElementById('loadingMessage');
+                                      if (overlay && messageEl) {
+                                          messageEl.textContent = message;
+                                          overlay.classList.add('active');
+                                      } else {
+                                          console.log('Loading:', message);
+                                      }
+                                  });
+            
+            if (mainShowLoading && mainShowLoading !== showLoading) {
+                mainShowLoading(message);
             } else {
                 console.log('Loading:', message);
             }
@@ -3433,8 +3447,28 @@
         }
 
         function showToast(message, type = 'info') {
-            if (typeof window.showToast === 'function') {
-                window.showToast(message, type);
+            // Look for the main showToast function in the parent document or other scope
+            const mainShowToast = window.parent?.showToast || 
+                                document.querySelector('script')?.showToast ||
+                                ((msg, tp) => {
+                                    const toast = document.createElement('div');
+                                    toast.className = `toast ${tp}`;
+                                    toast.innerHTML = `
+                                        <div style="display: flex; align-items: center; gap: 8px;">
+                                            <i class="fas fa-${tp === 'success' ? 'check-circle' : tp === 'error' ? 'exclamation-triangle' : 'info-circle'}"></i>
+                                            <span>${msg}</span>
+                                        </div>
+                                    `;
+                                    document.body.appendChild(toast);
+                                    setTimeout(() => toast.classList.add('show'), 100);
+                                    setTimeout(() => {
+                                        toast.classList.remove('show');
+                                        setTimeout(() => toast.remove(), 300);
+                                    }, 3000);
+                                });
+            
+            if (mainShowToast && mainShowToast !== showToast) {
+                mainShowToast(message, type);
             } else {
                 console.log(`${type.toUpperCase()}: ${message}`);
             }


### PR DESCRIPTION
Fix DICOM viewer navigation and recursion issues in `showLoading` and `showToast` functions.

The `nextImage` and `previousImage` functions were undefined, causing a `ReferenceError`. The `showLoading` and `showToast` functions were recursively calling themselves via `window` references, leading to "too much recursion" errors. This PR replaces undefined navigation calls with `navigateImage(direction)` and implements robust fallback logic for `showLoading` and `showToast` to prevent self-referential calls.

---
<a href="https://cursor.com/background-agent?bcId=bc-a42b8553-948d-41a2-a47a-0d458b912864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a42b8553-948d-41a2-a47a-0d458b912864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

