### PR TITLE
Fix dicom viewer errors and session issues

### DIFF
--- a/static/js/dicom-viewer-fixes.js
+++ b/static/js/dicom-viewer-fixes.js
@@ -129,6 +129,33 @@ function setupMissingFunctions() {
             // Reference search would be implemented here
         }
     };
+    
+    // Add nextImage and previousImage functions if they don't exist
+    window.nextImage = window.nextImage || function() {
+        if (typeof changeSlice === 'function') {
+            changeSlice(1);
+        } else if (window.currentImageIndex !== undefined && window.images) {
+            if (window.currentImageIndex < window.images.length - 1) {
+                window.currentImageIndex++;
+                if (typeof updateImageDisplay === 'function') {
+                    updateImageDisplay();
+                }
+            }
+        }
+    };
+    
+    window.previousImage = window.previousImage || function() {
+        if (typeof changeSlice === 'function') {
+            changeSlice(-1);
+        } else if (window.currentImageIndex !== undefined) {
+            if (window.currentImageIndex > 0) {
+                window.currentImageIndex--;
+                if (typeof updateImageDisplay === 'function') {
+                    updateImageDisplay();
+                }
+            }
+        }
+    };
 }
 
 function integrateMeasurementSystem() {
@@ -203,16 +230,24 @@ function fixCanvasEventHandlers() {
         } else {
             // Scroll through images
             if (e.deltaY > 0) {
-                if (typeof navigateImage === 'function') {
-                    navigateImage(1);
-                } else if (typeof window.navigateImage === 'function') {
-                    window.navigateImage(1);
+                if (typeof nextImage === 'function') {
+                    nextImage();
+                } else if (typeof window.nextImage === 'function') {
+                    window.nextImage();
+                } else if (typeof changeSlice === 'function') {
+                    changeSlice(1);
+                } else if (window.keyboardShortcuts && typeof window.keyboardShortcuts.nextImage === 'function') {
+                    window.keyboardShortcuts.nextImage();
                 }
             } else {
-                if (typeof navigateImage === 'function') {
-                    navigateImage(-1);
-                } else if (typeof window.navigateImage === 'function') {
-                    window.navigateImage(-1);
+                if (typeof previousImage === 'function') {
+                    previousImage();
+                } else if (typeof window.previousImage === 'function') {
+                    window.previousImage();
+                } else if (typeof changeSlice === 'function') {
+                    changeSlice(-1);
+                } else if (window.keyboardShortcuts && typeof window.keyboardShortcuts.previousImage === 'function') {
+                    window.keyboardShortcuts.previousImage();
                 }
             }
         }

--- a/static/js/session-timeout.js
+++ b/static/js/session-timeout.js
@@ -301,7 +301,12 @@ class SessionTimeoutManager {
                 method: 'GET',
                 credentials: 'same-origin'
             })
-            .then(response => response.json())
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+                }
+                return response.json();
+            })
             .then(data => {
                 if (!data.valid) {
                     this.performLogout();
@@ -309,6 +314,11 @@ class SessionTimeoutManager {
             })
             .catch(error => {
                 console.warn('Session check failed:', error);
+                // Only log out on authentication-related errors (401, 403)
+                // Don't log out on network errors or server issues
+                if (error.message.includes('401') || error.message.includes('403')) {
+                    this.performLogout();
+                }
             });
         }, 5 * 60 * 1000); // 5 minutes
     }

--- a/staticfiles/js/dicom-viewer-fixes.js
+++ b/staticfiles/js/dicom-viewer-fixes.js
@@ -129,6 +129,33 @@ function setupMissingFunctions() {
             // Reference search would be implemented here
         }
     };
+    
+    // Add nextImage and previousImage functions if they don't exist
+    window.nextImage = window.nextImage || function() {
+        if (typeof changeSlice === 'function') {
+            changeSlice(1);
+        } else if (window.currentImageIndex !== undefined && window.images) {
+            if (window.currentImageIndex < window.images.length - 1) {
+                window.currentImageIndex++;
+                if (typeof updateImageDisplay === 'function') {
+                    updateImageDisplay();
+                }
+            }
+        }
+    };
+    
+    window.previousImage = window.previousImage || function() {
+        if (typeof changeSlice === 'function') {
+            changeSlice(-1);
+        } else if (window.currentImageIndex !== undefined) {
+            if (window.currentImageIndex > 0) {
+                window.currentImageIndex--;
+                if (typeof updateImageDisplay === 'function') {
+                    updateImageDisplay();
+                }
+            }
+        }
+    };
 }
 
 function integrateMeasurementSystem() {
@@ -203,16 +230,24 @@ function fixCanvasEventHandlers() {
         } else {
             // Scroll through images
             if (e.deltaY > 0) {
-                if (typeof navigateImage === 'function') {
-                    navigateImage(1);
-                } else if (typeof window.navigateImage === 'function') {
-                    window.navigateImage(1);
+                if (typeof nextImage === 'function') {
+                    nextImage();
+                } else if (typeof window.nextImage === 'function') {
+                    window.nextImage();
+                } else if (typeof changeSlice === 'function') {
+                    changeSlice(1);
+                } else if (window.keyboardShortcuts && typeof window.keyboardShortcuts.nextImage === 'function') {
+                    window.keyboardShortcuts.nextImage();
                 }
             } else {
-                if (typeof navigateImage === 'function') {
-                    navigateImage(-1);
-                } else if (typeof window.navigateImage === 'function') {
-                    window.navigateImage(-1);
+                if (typeof previousImage === 'function') {
+                    previousImage();
+                } else if (typeof window.previousImage === 'function') {
+                    window.previousImage();
+                } else if (typeof changeSlice === 'function') {
+                    changeSlice(-1);
+                } else if (window.keyboardShortcuts && typeof window.keyboardShortcuts.previousImage === 'function') {
+                    window.keyboardShortcuts.previousImage();
                 }
             }
         }

--- a/staticfiles/js/session-timeout.js
+++ b/staticfiles/js/session-timeout.js
@@ -301,7 +301,12 @@ class SessionTimeoutManager {
                 method: 'GET',
                 credentials: 'same-origin'
             })
-            .then(response => response.json())
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+                }
+                return response.json();
+            })
             .then(data => {
                 if (!data.valid) {
                     this.performLogout();
@@ -309,6 +314,11 @@ class SessionTimeoutManager {
             })
             .catch(error => {
                 console.warn('Session check failed:', error);
+                // Only log out on authentication-related errors (401, 403)
+                // Don't log out on network errors or server issues
+                if (error.message.includes('401') || error.message.includes('403')) {
+                    this.performLogout();
+                }
             });
         }, 5 * 60 * 1000); // 5 minutes
     }


### PR DESCRIPTION
Fix `nextImage`/`previousImage` undefined errors and enhance session timeout handling for the DICOM viewer.

The DICOM viewer's mouse wheel navigation was broken due to missing `nextImage` and `previousImage` functions. Additionally, the session status check was incorrectly attempting to parse non-JSON responses (e.g., 404s), leading to spurious errors and potential logouts. This PR resolves these issues by implementing the missing navigation functions and making the session check more robust to prevent false positive logouts.

---
<a href="https://cursor.com/background-agent?bcId=bc-c370e725-ecb0-4df2-990e-b0256e992e39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c370e725-ecb0-4df2-990e-b0256e992e39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

