### PR TITLE
Adjust image size and brightness

### DIFF
--- a/static/css/high-quality-medical-imaging.css
+++ b/static/css/high-quality-medical-imaging.css
@@ -92,8 +92,8 @@
     .dicom-image,
     .dicom-canvas {
         /* Enhanced sharpening for high-DPI displays */
-        filter: contrast(1.2) brightness(1.1) saturate(1.05) blur(0.1px);
-        -webkit-filter: contrast(1.2) brightness(1.1) saturate(1.05) blur(0.1px);
+        filter: contrast(1.2) brightness(1.3) saturate(1.05) blur(0.1px);
+        -webkit-filter: contrast(1.2) brightness(1.3) saturate(1.05) blur(0.1px);
     }
 }
 
@@ -103,8 +103,8 @@
     .dicom-image,
     .dicom-canvas {
         /* Ultra-high-DPI enhancements */
-        filter: contrast(1.25) brightness(1.12) saturate(1.08) blur(0.05px);
-        -webkit-filter: contrast(1.25) brightness(1.12) saturate(1.08) blur(0.05px);
+        filter: contrast(1.25) brightness(1.35) saturate(1.08) blur(0.05px);
+        -webkit-filter: contrast(1.25) brightness(1.35) saturate(1.08) blur(0.05px);
     }
 }
 
@@ -128,8 +128,8 @@ canvas.dicom-canvas {
     image-rendering: high-quality;
     image-rendering: optimizeQuality;
     
-    filter: contrast(1.15) brightness(1.08) saturate(1.05);
-    -webkit-filter: contrast(1.15) brightness(1.08) saturate(1.05);
+    filter: contrast(1.15) brightness(1.25) saturate(1.05);
+    -webkit-filter: contrast(1.15) brightness(1.25) saturate(1.05);
     
     /* Hardware acceleration */
     transform: translateZ(0);

--- a/static/js/high-quality-image-renderer.js
+++ b/static/js/high-quality-image-renderer.js
@@ -72,7 +72,7 @@ class HighQualityImageRenderer {
         const canvasAspect = displayWidth / displayHeight;
         
         let drawWidth, drawHeight, drawX, drawY;
-        const fitScale = 0.80; // Scale factor to ensure image fits with margins
+        const fitScale = 0.60; // Scale factor to ensure image fits with margins (reduced for smaller display)
         
         if (imgAspect > canvasAspect) {
             drawWidth = displayWidth * fitScale;
@@ -133,30 +133,30 @@ class HighQualityImageRenderer {
             case 'DX':
             case 'CR':
             case 'MG':
-                // Digital Radiography, Computed Radiography, Mammography - Match reference image
-                this.ctx.filter = 'contrast(1.15) brightness(0.92) saturate(0.85)';
+                // Digital Radiography, Computed Radiography, Mammography - Brighter display
+                this.ctx.filter = 'contrast(1.15) brightness(1.1) saturate(0.85)';
                 break;
             case 'CT':
-                // Computed Tomography - Match reference characteristics
-                this.ctx.filter = 'contrast(1.12) brightness(0.94)';
+                // Computed Tomography - Brighter display
+                this.ctx.filter = 'contrast(1.12) brightness(1.1)';
                 break;
             case 'MR':
             case 'MRI':
-                // Magnetic Resonance - Match reference imaging
-                this.ctx.filter = 'contrast(1.10) brightness(0.93) saturate(0.95)';
+                // Magnetic Resonance - Brighter display
+                this.ctx.filter = 'contrast(1.10) brightness(1.1) saturate(0.95)';
                 break;
             case 'US':
-                // Ultrasound - Match reference brightness
-                this.ctx.filter = 'contrast(1.08) brightness(0.95)';
+                // Ultrasound - Brighter display
+                this.ctx.filter = 'contrast(1.08) brightness(1.1)';
                 break;
             case 'XA':
             case 'RF':
-                // X-Ray Angiography, Radiofluoroscopy - Match reference medical display
-                this.ctx.filter = 'contrast(1.16) brightness(0.91)';
+                // X-Ray Angiography, Radiofluoroscopy - Brighter display
+                this.ctx.filter = 'contrast(1.16) brightness(1.1)';
                 break;
             default:
-                // Default medical imaging - Match reference image
-                this.ctx.filter = 'contrast(1.12) brightness(0.93)';
+                // Default medical imaging - Brighter display
+                this.ctx.filter = 'contrast(1.12) brightness(1.1)';
         }
     }
 

--- a/templates/dicom_viewer/viewer.html
+++ b/templates/dicom_viewer/viewer.html
@@ -239,8 +239,8 @@
             image-rendering: high-quality;
             cursor: crosshair;
             transition: transform 0.1s ease;
-            filter: contrast(1.15) brightness(1.6);
-            -webkit-filter: contrast(1.15) brightness(1.6);
+            filter: contrast(1.15) brightness(1.9);
+            -webkit-filter: contrast(1.15) brightness(1.9);
         }
 
         .image-container {
@@ -278,8 +278,8 @@
             user-select: none;
             transition: none;
             /* Medical-grade image enhancement - BRIGHTER */
-            filter: contrast(1.15) brightness(1.6);
-            -webkit-filter: contrast(1.15) brightness(1.6);
+            filter: contrast(1.15) brightness(1.9);
+            -webkit-filter: contrast(1.15) brightness(1.9);
             /* Transform origin for zoom/pan */
             transform-origin: center center;
         }


### PR DESCRIPTION
Reduce DICOM image size and increase brightness across all display types and modalities.

The `fitScale` factor was reduced to make images smaller, and various CSS and JavaScript brightness filters were adjusted to address user feedback that images were not bright enough.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a5034b6-ed64-4f6a-aeca-23a2f9d6f0db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0a5034b6-ed64-4f6a-aeca-23a2f9d6f0db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

