### PR TITLE
Fix dicom viewer image loading and zoom

### DIFF
--- a/static/js/dicom-viewer-canvas-fix.js
+++ b/static/js/dicom-viewer-canvas-fix.js
@@ -73,39 +73,31 @@ class DicomCanvasFix {
     setupHighResolutionCanvas() {
         if (!this.canvas) return;
         
-        // Get device pixel ratio for high-DPI displays
-        const dpr = window.devicePixelRatio || 1;
+        // Get device pixel ratio for high-DPI displays but limit it for medical imaging
+        const dpr = Math.min(window.devicePixelRatio || 1, 2); // Cap DPR at 2 to prevent over-scaling
         const rect = this.canvas.getBoundingClientRect();
         
         // Detect modality for resolution optimization
         const modality = this.detectModality();
         
-        // Modality-specific resolution multipliers - OPTIMIZED for X-ray vs CT
-        let resolutionMultiplier = 1.0; // Default - standard scaling
-        if (['DX', 'CR', 'DR', 'XA', 'RF'].includes(modality)) {
-            resolutionMultiplier = 0.8; // X-ray images - reduced scaling to prevent over-zoom
-        } else if (['CT'].includes(modality)) {
-            resolutionMultiplier = 1.0; // CT - standard resolution
-        } else if (['MR', 'MRI'].includes(modality)) {
-            resolutionMultiplier = 1.0; // MRI - standard resolution
-        } else if (['US'].includes(modality)) {
-            resolutionMultiplier = 1.0; // Ultrasound - standard resolution
-        }
+        // Simplified resolution multipliers - FIXED for normal display
+        let resolutionMultiplier = 1.0; // Standard scaling for all modalities
         
-        this.canvas.width = rect.width * dpr * resolutionMultiplier;
-        this.canvas.height = rect.height * dpr * resolutionMultiplier;
+        // Set canvas internal dimensions
+        this.canvas.width = rect.width * dpr;
+        this.canvas.height = rect.height * dpr;
         
         // Scale canvas back down using CSS
         this.canvas.style.width = rect.width + 'px';
         this.canvas.style.height = rect.height + 'px';
         
-        // Scale the drawing context to match
-        this.ctx.scale(dpr * resolutionMultiplier, dpr * resolutionMultiplier);
+        // Scale the drawing context to match - IMPORTANT: Only scale by DPR, not resolution multiplier
+        this.ctx.scale(dpr, dpr);
         
         // Set canvas modality attribute for future reference
         this.canvas.dataset.modality = modality;
         
-        console.log(`High-resolution canvas setup for ${modality}: ${this.canvas.width}x${this.canvas.height} (${resolutionMultiplier}x DPR: ${dpr})`);
+        console.log(`High-resolution canvas setup for ${modality}: ${this.canvas.width}x${this.canvas.height} (DPR: ${dpr}, Display: ${rect.width}x${rect.height})`);
     }
 
     setupEventListeners() {
@@ -375,20 +367,29 @@ class DicomCanvasFix {
         }
 
         if (image instanceof HTMLImageElement) {
-            // Store current image
-            this.currentImage = image;
+        // Store current image
+        this.currentImage = image;
+        
+        // Reset any existing zoom/pan to ensure proper fit
+        if (typeof window.zoom !== 'undefined') {
+            window.zoom = 1.0;
+        }
+        if (typeof window.panX !== 'undefined') {
+            window.panX = 0;
+            window.panY = 0;
+        }
+        
+        try {
+            // Detect modality from various sources (with fallback)
+            const modality = this.detectModality(metadata);
             
-            try {
-                // Detect modality from various sources (with fallback)
-                const modality = this.detectModality(metadata);
-                
-                // Use modality-specific display
-                this.modalitySpecificDisplayImage(image, modality);
-            } catch (error) {
-                console.warn('Modality-specific display failed, using basic display:', error);
-                // Fallback to basic display if modality-specific fails
-                this.basicDisplayImage(image);
-            }
+            // Use modality-specific display
+            this.modalitySpecificDisplayImage(image, modality);
+        } catch (error) {
+            console.warn('Modality-specific display failed, using basic display:', error);
+            // Fallback to basic display if modality-specific fails
+            this.basicDisplayImage(image);
+        }
         }
     }
 
@@ -444,33 +445,31 @@ class DicomCanvasFix {
         this.ctx.fillStyle = '#000';
         this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
 
-        // Calculate image dimensions and positioning
-        const canvasAspect = this.canvas.width / this.canvas.height;
+        // Get the actual canvas display dimensions (not the high-resolution internal dimensions)
+        const canvasDisplayWidth = this.canvas.offsetWidth || this.canvas.clientWidth;
+        const canvasDisplayHeight = this.canvas.offsetHeight || this.canvas.clientHeight;
+        
+        // Calculate image dimensions and positioning for normal fit
+        const canvasAspect = canvasDisplayWidth / canvasDisplayHeight;
         const imageAspect = image.width / image.height;
         
         let drawWidth, drawHeight, drawX, drawY;
         
-        // Display image at actual size - no scaling unless it exceeds canvas bounds
-        const maxWidth = this.canvas.width * 0.95; // 95% of canvas width max
-        const maxHeight = this.canvas.height * 0.95; // 95% of canvas height max
+        // Fit image to canvas with proper aspect ratio - NORMAL SIZE FIT
+        const maxWidth = canvasDisplayWidth * 0.9; // 90% of display width
+        const maxHeight = canvasDisplayHeight * 0.9; // 90% of display height
         
-        // Start with actual image dimensions
-        drawWidth = image.width;
-        drawHeight = image.height;
+        // Calculate scale to fit image properly
+        const scaleX = maxWidth / image.width;
+        const scaleY = maxHeight / image.height;
+        const scale = Math.min(scaleX, scaleY); // Always scale to fit
         
-        // Only scale down if image is larger than canvas
-        if (drawWidth > maxWidth || drawHeight > maxHeight) {
-            const scaleX = maxWidth / drawWidth;
-            const scaleY = maxHeight / drawHeight;
-            const scale = Math.min(scaleX, scaleY);
-            
-            drawWidth = drawWidth * scale;
-            drawHeight = drawHeight * scale;
-        }
+        drawWidth = image.width * scale;
+        drawHeight = image.height * scale;
         
-        // Center the image
-        drawX = (this.canvas.width - drawWidth) / 2;
-        drawY = (this.canvas.height - drawHeight) / 2;
+        // Center the image on the display canvas
+        drawX = (canvasDisplayWidth - drawWidth) / 2;
+        drawY = (canvasDisplayHeight - drawHeight) / 2;
         
         // Apply modality-specific rendering settings
         this.applyModalityRenderingSettings(modality);
@@ -489,8 +488,10 @@ class DicomCanvasFix {
             height: drawHeight,
             originalWidth: image.width,
             originalHeight: image.height,
-            scaleFactor: Math.min(drawWidth / image.width, drawHeight / image.height),
-            modality: modality
+            scaleFactor: scale, // Use the calculated fit scale
+            modality: modality,
+            displayWidth: canvasDisplayWidth,
+            displayHeight: canvasDisplayHeight
         };
         
         console.log(`Image displayed successfully with ${modality}-specific rendering`);
@@ -559,23 +560,29 @@ class DicomCanvasFix {
             this.ctx.fillStyle = '#000';
             this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
 
-            // Calculate image dimensions and positioning
-            const canvasAspect = this.canvas.width / this.canvas.height;
+            // Get the actual canvas display dimensions
+            const canvasDisplayWidth = this.canvas.offsetWidth || this.canvas.clientWidth;
+            const canvasDisplayHeight = this.canvas.offsetHeight || this.canvas.clientHeight;
+            
+            // Calculate image dimensions and positioning for proper fit
+            const canvasAspect = canvasDisplayWidth / canvasDisplayHeight;
             const imageAspect = image.width / image.height;
             
             let drawWidth, drawHeight, drawX, drawY;
-            const scaleFactor = 0.60; // Reduced for better fit in basic display mode
             
-            if (imageAspect > canvasAspect) {
-                drawWidth = this.canvas.width * scaleFactor;
-                drawHeight = drawWidth / imageAspect;
-            } else {
-                drawHeight = this.canvas.height * scaleFactor;
-                drawWidth = drawHeight * imageAspect;
-            }
+            // Fit image to 85% of display canvas to ensure it's not too large
+            const maxWidth = canvasDisplayWidth * 0.85;
+            const maxHeight = canvasDisplayHeight * 0.85;
             
-            drawX = (this.canvas.width - drawWidth) / 2;
-            drawY = (this.canvas.height - drawHeight) / 2;
+            const scaleX = maxWidth / image.width;
+            const scaleY = maxHeight / image.height;
+            const scale = Math.min(scaleX, scaleY);
+            
+            drawWidth = image.width * scale;
+            drawHeight = image.height * scale;
+            
+            drawX = (canvasDisplayWidth - drawWidth) / 2;
+            drawY = (canvasDisplayHeight - drawHeight) / 2;
             
             // Safe rendering settings - Increased brightness for better visibility
             this.ctx.globalAlpha = 1.0;
@@ -596,7 +603,9 @@ class DicomCanvasFix {
                 height: drawHeight,
                 originalWidth: image.width,
                 originalHeight: image.height,
-                scaleFactor: Math.min(drawWidth / image.width, drawHeight / image.height)
+                scaleFactor: scale,
+                displayWidth: canvasDisplayWidth,
+                displayHeight: canvasDisplayHeight
             };
             
             console.log('Image displayed successfully with safe basic rendering');
@@ -666,6 +675,28 @@ class DicomCanvasFix {
                 }
             }
         }
+    }
+
+    // Method to reset zoom to fit the image properly
+    resetZoomToFit() {
+        if (!this.currentImage || !this.canvas) return;
+        
+        // Clear any existing zoom/pan transformations
+        if (typeof window.zoom !== 'undefined') {
+            window.zoom = 1.0;
+        }
+        if (typeof window.panX !== 'undefined') {
+            window.panX = 0;
+            window.panY = 0;
+        }
+        
+        // Redisplay current image with proper fit
+        const cachedImage = this.imageCache.get(this.currentImage.id) || this.currentImage;
+        if (cachedImage) {
+            this.displayImage(cachedImage, this.currentImage);
+        }
+        
+        console.log('Zoom reset to fit image properly');
     }
 }
 

--- a/static/js/dicom-viewer-fixes.js
+++ b/static/js/dicom-viewer-fixes.js
@@ -582,7 +582,7 @@ window.startWindowLevel = 0;
 window.startWindowWidth = 0;
 window.startPanX = 0;
 window.startPanY = 0;
-window.zoom = 0.8; // Optimized initial zoom for medical imaging
+window.zoom = 1.0; // Normal initial zoom - let the canvas fit handle proper sizing
 window.panX = 0;
 window.panY = 0;
 window.windowWidth = 256;
@@ -822,16 +822,25 @@ window.activeTool = 'windowing';
 
 // Reset zoom function - FIXED for proper fit
 window.resetZoom = function() {
-    window.zoom = 0.8; // Reset to optimized zoom level for medical imaging
+    // Use the canvas fix's reset method if available
+    if (window.dicomCanvasFix && typeof window.dicomCanvasFix.resetZoomToFit === 'function') {
+        window.dicomCanvasFix.resetZoomToFit();
+        return;
+    }
+    
+    // Fallback method
+    window.zoom = 1.0; // Reset to normal zoom level
     window.panX = 0;
     window.panY = 0;
     
     // Redraw current image if available
     if (window.currentImageElement) {
         window.renderImageToCanvas(window.currentImageElement);
+    } else if (typeof updateImageDisplay === 'function') {
+        updateImageDisplay();
     }
     
-    console.log('Zoom reset to proper fit level (0.8x)');
+    console.log('Zoom reset to fit properly');
 };
 
 // Add modality-specific zoom adjustment function

--- a/templates/dicom_viewer/viewer.html
+++ b/templates/dicom_viewer/viewer.html
@@ -973,6 +973,10 @@
                     <i class="fas fa-search-plus"></i>
                     <span>Zoom</span>
                 </button>
+                <button class="tool" onclick="resetZoom()" title="Reset Zoom to Fit">
+                    <i class="fas fa-expand-arrows-alt"></i>
+                    <span>Fit</span>
+                </button>
                 <button class="tool" data-tool="pan" onclick="setTool('pan')" title="Pan">
                     <i class="fas fa-hand-paper"></i>
                     <span>Pan</span>
@@ -2712,13 +2716,13 @@
         }
 
         function resetView() {
-            zoomFactor = 0.8; // Reset to better fitting zoom level
+            zoomFactor = 1.0; // Reset to normal zoom level - let canvas fix handle proper fit
             panX = 0;
             panY = 0;
             
-            document.getElementById('zoomSlider').value = 80;
-            document.getElementById('zoomValue').textContent = '80%';
-            document.getElementById('zoomInfo').textContent = 'Zoom: 80%';
+            document.getElementById('zoomSlider').value = 100;
+            document.getElementById('zoomValue').textContent = '100%';
+            document.getElementById('zoomInfo').textContent = 'Zoom: 100%';
             
             applyTransform();
             updateZoomInfo();

--- a/test_zoom_fix.html
+++ b/test_zoom_fix.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DICOM Zoom Fix Test</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 20px;
+            background: #000;
+            color: white;
+            font-family: Arial, sans-serif;
+        }
+        .test-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 20px;
+        }
+        .canvas-container {
+            border: 2px solid #333;
+            width: 800px;
+            height: 600px;
+            position: relative;
+            background: #111;
+        }
+        #dicom-canvas {
+            width: 100%;
+            height: 100%;
+        }
+        .controls {
+            display: flex;
+            gap: 10px;
+        }
+        button {
+            padding: 10px 20px;
+            background: #00d4ff;
+            color: black;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        button:hover {
+            background: #00b4df;
+        }
+        .info {
+            background: #222;
+            padding: 15px;
+            border-radius: 8px;
+            max-width: 800px;
+        }
+    </style>
+</head>
+<body>
+    <div class="test-container">
+        <h1>DICOM Viewer Zoom Fix Test</h1>
+        
+        <div class="info">
+            <h3>Test Status:</h3>
+            <p id="status">Loading canvas fix...</p>
+            <p><strong>Expected Result:</strong> Images should display at normal size, fitting properly within the canvas without appearing zoomed in.</p>
+        </div>
+
+        <div class="canvas-container">
+            <canvas id="dicom-canvas"></canvas>
+        </div>
+
+        <div class="controls">
+            <button onclick="testImageDisplay()">Test Image Display</button>
+            <button onclick="resetZoom()">Reset Zoom</button>
+            <button onclick="testHighDPR()">Test High DPR</button>
+        </div>
+
+        <div class="info">
+            <h3>Test Results:</h3>
+            <ul id="results"></ul>
+        </div>
+    </div>
+
+    <script src="/static/js/dicom-viewer-canvas-fix.js"></script>
+    <script src="/static/js/dicom-viewer-fixes.js"></script>
+    <script>
+        let testResults = [];
+
+        function addResult(test, result, details = '') {
+            testResults.push({test, result, details});
+            updateResults();
+        }
+
+        function updateResults() {
+            const resultsEl = document.getElementById('results');
+            resultsEl.innerHTML = '';
+            testResults.forEach(r => {
+                const li = document.createElement('li');
+                li.innerHTML = `<strong>${r.test}:</strong> <span style="color: ${r.result === 'PASS' ? '#00ff88' : '#ff4444'}">${r.result}</span> ${r.details}`;
+                resultsEl.appendChild(li);
+            });
+        }
+
+        function testImageDisplay() {
+            // Create a test image
+            const img = new Image();
+            img.onload = function() {
+                // Test if canvas fix is working
+                if (window.dicomCanvasFix) {
+                    addResult('Canvas Fix Loaded', 'PASS', 'DicomCanvasFix instance available');
+                    
+                    // Test image display
+                    try {
+                        window.dicomCanvasFix.displayImage(img);
+                        addResult('Image Display', 'PASS', `Image displayed: ${img.width}x${img.height}`);
+                        
+                        // Check if image info is stored correctly
+                        if (window.dicomCanvasFix.imageInfo) {
+                            const info = window.dicomCanvasFix.imageInfo;
+                            addResult('Scale Factor', info.scaleFactor < 1.2 && info.scaleFactor > 0.5 ? 'PASS' : 'FAIL', 
+                                     `Scale: ${info.scaleFactor.toFixed(3)}`);
+                        }
+                    } catch (error) {
+                        addResult('Image Display', 'FAIL', error.message);
+                    }
+                } else {
+                    addResult('Canvas Fix Loaded', 'FAIL', 'DicomCanvasFix not available');
+                }
+            };
+            
+            // Create a test pattern image
+            const canvas = document.createElement('canvas');
+            canvas.width = 512;
+            canvas.height = 512;
+            const ctx = canvas.getContext('2d');
+            
+            // Draw test pattern
+            ctx.fillStyle = '#444';
+            ctx.fillRect(0, 0, 512, 512);
+            ctx.fillStyle = '#fff';
+            ctx.fillRect(50, 50, 412, 412);
+            ctx.fillStyle = '#000';
+            ctx.font = '24px Arial';
+            ctx.textAlign = 'center';
+            ctx.fillText('Test DICOM Image', 256, 256);
+            ctx.fillText('512x512 pixels', 256, 300);
+            
+            img.src = canvas.toDataURL();
+        }
+
+        function testHighDPR() {
+            const dpr = window.devicePixelRatio || 1;
+            addResult('Device Pixel Ratio', 'INFO', `DPR: ${dpr}`);
+            
+            if (window.dicomCanvasFix && window.dicomCanvasFix.canvas) {
+                const canvas = window.dicomCanvasFix.canvas;
+                const displayWidth = canvas.offsetWidth;
+                const displayHeight = canvas.offsetHeight;
+                const internalWidth = canvas.width;
+                const internalHeight = canvas.height;
+                
+                addResult('Canvas Dimensions', 'INFO', 
+                         `Display: ${displayWidth}x${displayHeight}, Internal: ${internalWidth}x${internalHeight}`);
+                
+                const scalingRatio = internalWidth / displayWidth;
+                addResult('Canvas Scaling', scalingRatio <= 2 ? 'PASS' : 'FAIL', 
+                         `Scaling ratio: ${scalingRatio.toFixed(2)} (should be ≤2)`);
+            }
+        }
+
+        // Initialize tests
+        setTimeout(() => {
+            if (window.dicomCanvasFix) {
+                document.getElementById('status').textContent = 'Canvas fix loaded successfully!';
+                addResult('Initialization', 'PASS', 'DICOM canvas fix initialized');
+            } else {
+                document.getElementById('status').textContent = 'Canvas fix failed to load!';
+                addResult('Initialization', 'FAIL', 'DICOM canvas fix not found');
+            }
+        }, 1000);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Fix DICOM viewer images appearing zoomed in by correcting canvas scaling and image fitting logic.

The previous implementation caused images to appear excessively large due to over-scaling of the high-resolution canvas and incorrect calculation of image display dimensions. This PR ensures images fit properly within the viewer, resets zoom on image load, and adds a "Fit" button for manual reset.

---
<a href="https://cursor.com/background-agent?bcId=bc-80befe01-99c7-46f4-8f83-857b30429e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-80befe01-99c7-46f4-8f83-857b30429e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

