### PR TITLE
Handle api image data none type error

### DIFF
--- a/dicom_viewer/admin.py
+++ b/dicom_viewer/admin.py
@@ -84,8 +84,8 @@ class MeasurementAdmin(admin.ModelAdmin):
     def image_info(self, obj):
         return format_html(
             '<strong>Series {}</strong><br><small>{}</small>',
-            obj.image.series.series_number,
-            obj.image.series.study.accession_number
+            obj.image.series.series_number if obj.image.series else 'Unknown',
+            obj.image.series.study.accession_number if obj.image.series and obj.image.series.study else 'Unknown'
         )
     image_info.short_description = 'Image'
     
@@ -106,8 +106,8 @@ class AnnotationAdmin(admin.ModelAdmin):
     def image_info(self, obj):
         return format_html(
             '<strong>Series {}</strong><br><small>{}</small>',
-            obj.image.series.series_number,
-            obj.image.series.study.accession_number
+            obj.image.series.series_number if obj.image.series else 'Unknown',
+            obj.image.series.study.accession_number if obj.image.series and obj.image.series.study else 'Unknown'
         )
     image_info.short_description = 'Image'
     
@@ -133,8 +133,8 @@ class ReconstructionJobAdmin(admin.ModelAdmin):
     def series_info(self, obj):
         return format_html(
             '<strong>Series {}</strong><br><small>{}</small>',
-            obj.series.series_number,
-            obj.series.study.accession_number
+            obj.series.series_number if obj.series else 'Unknown',
+            obj.series.study.accession_number if obj.series and obj.series.study else 'Unknown'
         )
     series_info.short_description = 'Series'
     

--- a/dicom_viewer/masterpiece_utils.py
+++ b/dicom_viewer/masterpiece_utils.py
@@ -451,11 +451,15 @@ class MasterpieceVolumeBuilder:
             'modality': self.series.modality,
             'rows': first_image.file_path.name if first_image else None,
             'columns': first_image.file_path.name if first_image else None,
-            'study_date': self.series.study.study_date.isoformat() if self.series.study.study_date else None,
+            'study_date': (self.series.study.study_date.isoformat() 
+                         if self.series.study and self.series.study.study_date else None),
             'patient_info': {
-                'name': self.series.study.patient.full_name if self.series.study.patient else None,
-                'id': self.series.study.patient.patient_id if self.series.study.patient else None,
-                'age': self.series.study.patient.date_of_birth if self.series.study.patient else None
+                'name': (self.series.study.patient.full_name 
+                        if self.series.study and self.series.study.patient else None),
+                'id': (self.series.study.patient.patient_id 
+                      if self.series.study and self.series.study.patient else None),
+                'age': (self.series.study.patient.date_of_birth 
+                       if self.series.study and self.series.study.patient else None)
             }
         }
         

--- a/dicom_viewer/views.py
+++ b/dicom_viewer/views.py
@@ -3976,10 +3976,18 @@ def print_dicom_image(request):
                     # Extract comprehensive metadata
                     enhanced_metadata = file_handler.extract_dicom_metadata(ds)
                     enhanced_metadata.update({
-                        'facility': image.series.study.facility.name if image.series.study.facility else 'Unknown',
-                        'accession_number': image.series.study.accession_number,
-                        'study_uid': image.series.study.study_instance_uid,
-                        'series_uid': image.series.series_instance_uid,
+                        'facility': (image.series.study.facility.name 
+                                   if image.series and image.series.study and image.series.study.facility 
+                                   else 'Unknown'),
+                        'accession_number': (image.series.study.accession_number 
+                                           if image.series and image.series.study 
+                                           else 'Unknown'),
+                        'study_uid': (image.series.study.study_instance_uid 
+                                    if image.series and image.series.study 
+                                    else 'Unknown'),
+                        'series_uid': (image.series.series_instance_uid 
+                                     if image.series 
+                                     else 'Unknown'),
                         'image_uid': image.sop_instance_uid,
                         'slice_location': image.slice_location,
                         'instance_number': image.instance_number,
@@ -6031,7 +6039,9 @@ def api_image_data_professional(request, image_id):
         
         # Check facility permissions
         if user.is_facility_user() and getattr(user, 'facility', None):
-            if image.series.study.facility != user.facility:
+            if (not image.series or not image.series.study or 
+                not image.series.study.facility or 
+                image.series.study.facility != user.facility):
                 return JsonResponse({'error': 'Permission denied'}, status=403)
         
         # Load DICOM file
@@ -6216,7 +6226,9 @@ def api_ai_analysis(request):
         
         # Check facility permissions
         if user.is_facility_user() and getattr(user, 'facility', None):
-            if image.series.study.facility != user.facility:
+            if (not image.series or not image.series.study or 
+                not image.series.study.facility or 
+                image.series.study.facility != user.facility):
                 return JsonResponse({'error': 'Permission denied'}, status=403)
         
         # Simulate AI analysis (in production, this would call actual AI models)
@@ -6283,7 +6295,9 @@ def api_image_data(request, image_id):
         
         # Check facility permissions
         if user.is_facility_user() and getattr(user, 'facility', None):
-            if image.series.study.facility != user.facility:
+            if (not image.series or not image.series.study or 
+                not image.series.study.facility or 
+                image.series.study.facility != user.facility):
                 return JsonResponse({'error': 'Permission denied'}, status=403)
         
         # Read DICOM file and extract pixel data


### PR DESCRIPTION
Add null checks to prevent `NoneType` errors when accessing nested Django model relationships in permission checks and metadata extraction.

The `NoneType` error occurred because `image.series`, `image.series.study`, or `image.series.study.facility` could be `None`, leading to crashes when attempting to access attributes like `.study` or `.facility`. This fix ensures that these relationships are checked for existence before being subscripted, making the application more robust against incomplete data.

---
<a href="https://cursor.com/background-agent?bcId=bc-dd3ec8b5-8cb1-45a6-be1f-665c1ac51c31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dd3ec8b5-8cb1-45a6-be1f-665c1ac51c31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

