### PR TITLE
Initialize and load dicom viewer with performance tracking

### DIFF
--- a/static/js/dicom-3d-enhanced.js
+++ b/static/js/dicom-3d-enhanced.js
@@ -994,13 +994,23 @@ class Enhanced3DReconstruction {
     }
 
     handleResize() {
-        const container = document.getElementById('viewport3DContainer');
-        if (!container) return;
+        try {
+            const container = document.getElementById('viewport3DContainer');
+            if (!container) return;
 
-        const rect = container.getBoundingClientRect();
-        this.renderer.setSize(rect.width, rect.height);
-        this.camera.aspect = rect.width / rect.height;
-        this.camera.updateProjectionMatrix();
+            const rect = container.getBoundingClientRect();
+            if (rect && rect.width > 0 && rect.height > 0) {
+                if (this.renderer) {
+                    this.renderer.setSize(rect.width, rect.height);
+                }
+                if (this.camera) {
+                    this.camera.aspect = rect.width / rect.height;
+                    this.camera.updateProjectionMatrix();
+                }
+            }
+        } catch (error) {
+            console.error('Error in 3D handleResize:', error);
+        }
     }
 
     showLoading(show) {

--- a/static/js/dicom-mobile-support.js
+++ b/static/js/dicom-mobile-support.js
@@ -654,21 +654,27 @@ class DicomMobileSupport {
     }
     
     handleResize() {
-        const canvas = document.getElementById('dicomCanvas');
-        if (!canvas) return;
-        
-        if (this.isMobile) {
-            // Adjust canvas size for mobile
-            const container = canvas.parentElement;
-            if (container) {
-                canvas.width = container.clientWidth;
-                canvas.height = window.innerHeight - 120; // Account for toolbar
+        try {
+            const canvas = document.getElementById('dicomCanvas');
+            if (!canvas) return;
+            
+            if (this.isMobile) {
+                // Adjust canvas size for mobile
+                const container = canvas.parentElement;
+                if (container && container.clientWidth && container.clientHeight) {
+                    canvas.width = container.clientWidth;
+                    canvas.height = window.innerHeight - 120; // Account for toolbar
+                }
             }
-        }
-        
-        // Re-render if viewer is available
-        if (this.viewer && this.viewer.renderer && this.viewer.currentImage) {
-            this.viewer.renderer.handleResize();
+            
+            // Re-render if viewer is available
+            if (this.viewer && this.viewer.renderer && this.viewer.currentImage) {
+                if (typeof this.viewer.renderer.handleResize === 'function') {
+                    this.viewer.renderer.handleResize();
+                }
+            }
+        } catch (error) {
+            console.error('Error in mobile handleResize:', error);
         }
     }
     

--- a/test-resize.html
+++ b/test-resize.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test Resize Fix</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 20px;
+            font-family: Arial, sans-serif;
+        }
+        #testContainer {
+            width: 800px;
+            height: 600px;
+            border: 2px solid #333;
+            position: relative;
+            margin: 20px auto;
+            background: #f0f0f0;
+        }
+        #dicomCanvas {
+            width: 100%;
+            height: 100%;
+            background: white;
+        }
+        .controls {
+            text-align: center;
+            margin: 20px;
+        }
+        button {
+            padding: 10px 20px;
+            margin: 5px;
+            cursor: pointer;
+        }
+        #log {
+            margin: 20px;
+            padding: 10px;
+            border: 1px solid #ccc;
+            background: #f9f9f9;
+            max-height: 200px;
+            overflow-y: auto;
+        }
+        .log-entry {
+            margin: 5px 0;
+            padding: 5px;
+            border-left: 3px solid #007bff;
+            background: white;
+        }
+        .error {
+            border-left-color: #dc3545;
+            background: #fff5f5;
+        }
+        .success {
+            border-left-color: #28a745;
+            background: #f5fff5;
+        }
+    </style>
+</head>
+<body>
+    <h1>Testing Resize Fix for DICOM Viewer</h1>
+    
+    <div class="controls">
+        <button onclick="testResize()">Test Resize</button>
+        <button onclick="removeContainer()">Remove Container</button>
+        <button onclick="restoreContainer()">Restore Container</button>
+        <button onclick="triggerWindowResize()">Trigger Window Resize</button>
+        <button onclick="clearLog()">Clear Log</button>
+    </div>
+
+    <div id="testContainer">
+        <canvas id="dicomCanvas"></canvas>
+    </div>
+
+    <div id="log">
+        <div class="log-entry">Test page loaded. Click buttons to test resize functionality.</div>
+    </div>
+
+    <script src="/static/js/dicom-viewer-professional.js"></script>
+    <script>
+        let viewer;
+        let originalContainer;
+
+        function addLog(message, type = 'info') {
+            const log = document.getElementById('log');
+            const entry = document.createElement('div');
+            entry.className = 'log-entry ' + type;
+            const timestamp = new Date().toLocaleTimeString();
+            entry.textContent = `[${timestamp}] ${message}`;
+            log.appendChild(entry);
+            log.scrollTop = log.scrollHeight;
+        }
+
+        async function initViewer() {
+            try {
+                viewer = new ProfessionalDicomViewer();
+                await viewer.init();
+                addLog('Viewer initialized successfully', 'success');
+            } catch (error) {
+                addLog(`Initialization error: ${error.message}`, 'error');
+            }
+        }
+
+        function testResize() {
+            try {
+                if (!viewer || !viewer.renderer) {
+                    addLog('Viewer not initialized', 'error');
+                    return;
+                }
+                
+                addLog('Testing handleResize...');
+                viewer.renderer.handleResize();
+                addLog('handleResize completed without errors', 'success');
+            } catch (error) {
+                addLog(`Resize error: ${error.message}`, 'error');
+                console.error(error);
+            }
+        }
+
+        function removeContainer() {
+            const container = document.getElementById('testContainer');
+            if (container) {
+                originalContainer = container.parentNode.removeChild(container);
+                addLog('Container removed from DOM');
+                
+                // Try to resize after container is removed
+                setTimeout(() => {
+                    addLog('Attempting resize with removed container...');
+                    testResize();
+                }, 100);
+            }
+        }
+
+        function restoreContainer() {
+            if (originalContainer) {
+                const controls = document.querySelector('.controls');
+                controls.parentNode.insertBefore(originalContainer, controls.nextSibling);
+                addLog('Container restored to DOM', 'success');
+                
+                // Re-initialize canvas
+                setTimeout(() => {
+                    if (viewer && viewer.renderer) {
+                        viewer.renderer.canvas = document.getElementById('dicomCanvas');
+                        addLog('Canvas reference updated');
+                    }
+                }, 100);
+            }
+        }
+
+        function triggerWindowResize() {
+            addLog('Triggering window resize event...');
+            window.dispatchEvent(new Event('resize'));
+            setTimeout(() => {
+                addLog('Window resize event completed');
+            }, 100);
+        }
+
+        function clearLog() {
+            const log = document.getElementById('log');
+            log.innerHTML = '<div class="log-entry">Log cleared</div>';
+        }
+
+        // Initialize on page load
+        window.addEventListener('DOMContentLoaded', () => {
+            initViewer();
+            
+            // Override console methods to capture logs
+            const originalWarn = console.warn;
+            const originalError = console.error;
+            const originalLog = console.log;
+            
+            console.warn = function(...args) {
+                originalWarn.apply(console, args);
+                addLog(`WARN: ${args.join(' ')}`, 'error');
+            };
+            
+            console.error = function(...args) {
+                originalError.apply(console, args);
+                addLog(`ERROR: ${args.join(' ')}`, 'error');
+            };
+            
+            console.log = function(...args) {
+                originalLog.apply(console, args);
+                const message = args.join(' ');
+                if (message.includes('✅')) {
+                    addLog(message, 'success');
+                } else if (!message.includes('Performance Stats')) {
+                    addLog(message);
+                }
+            };
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Add robust null checks and error handling to resize functions to prevent crashes when DOM elements are unavailable.

The application was crashing with `TypeError: can't access property "clientWidth", container is null` during window resize events. This occurred when container elements were not yet rendered or had been removed from the DOM. This PR adds comprehensive checks and try-catch blocks to ensure graceful handling of such scenarios, improving application stability.

---
<a href="https://cursor.com/background-agent?bcId=bc-c729a9fb-8886-4ac8-9a9f-462569351cff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c729a9fb-8886-4ac8-9a9f-462569351cff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

