### PR TITLE
Initialize and load dicom viewer with errors

### DIFF
--- a/static/js/enhanced-search.js
+++ b/static/js/enhanced-search.js
@@ -12,8 +12,6 @@ class EnhancedSearch {
     
     init() {
         this.enhanceExistingSearch();
-        this.addSearchSuggestions();
-        this.addSearchHistory();
     }
     
     enhanceExistingSearch() {

--- a/templates/dicom_viewer/masterpiece_viewer.html
+++ b/templates/dicom_viewer/masterpiece_viewer.html
@@ -2765,7 +2765,7 @@
                 const searchQuery = query || (currentStudy ? currentStudy.description : '');
                 
                 // Make API call to fetch references (adjust endpoint as needed)
-                const response = await fetch(`/ai/search-references/?q=${encodeURIComponent(searchQuery)}`);
+                const response = await fetch(`/ai/api/references/?q=${encodeURIComponent(searchQuery)}`);
                 
                 if (response.ok) {
                     const data = await response.json();


### PR DESCRIPTION
Fixes critical JavaScript errors in enhanced search, DICOM WebGL rendering, and AI reference fetching.

This PR addresses three distinct issues:
1.  **Enhanced Search:** Removes calls to non-existent `addSearchSuggestions()` and `addSearchHistory()` methods in `enhanced-search.js`.
2.  **WebGL Texture:** Corrects `createTexture()` in `dicom-viewer-professional.js` to always return a valid `WebGLTexture` object (not a Promise) and adds texture validation before binding, resolving a `TypeError`.
3.  **API Endpoint:** Updates the AI reference API endpoint in `masterpiece_viewer.html` from `/ai/search-references/` to `/ai/api/references/` to resolve a 404 error.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef5b14be-e699-475f-ab94-efb0e95a4d27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ef5b14be-e699-475f-ab94-efb0e95a4d27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

