### PR TITLE
Initialize and debug dicom viewer loading

### DIFF
--- a/WEBGL_TEXTURE_FIX.md
+++ b/WEBGL_TEXTURE_FIX.md
@@ -1,0 +1,115 @@
+# WebGL Texture Binding Error - FIXED
+
+## Problem Summary
+The DICOM viewer was failing to display images with the error:
+```
+TypeError: WebGL2RenderingContext.bindTexture: Argument 2 does not implement interface WebGLTexture.
+```
+
+## Root Causes Identified
+
+### 1. **Primary Issue: Context Mismatch in Fallback Rendering**
+When WebGL rendering failed and tried to fall back to 2D rendering, the `render2D` function was using `this.context`, which was still pointing to the WebGL context instead of a 2D context. This caused the 2D rendering to fail completely.
+
+**Solution:**
+- Added a separate `context2d` property to store the 2D rendering context
+- When WebGL is enabled, create a hidden 2D canvas for fallback rendering
+- Modified `render2D` to use `this.context2d` instead of `this.context`
+- After 2D fallback rendering, copy the result to the main canvas
+
+### 2. **Secondary Issue: Insufficient Error Handling in WebGL Texture Creation**
+The `createTexture` function could return `null` or an invalid texture, but the calling code would still try to bind it, causing the error.
+
+**Solution:**
+- Added comprehensive logging to track texture creation process
+- Added validation before binding textures
+- Added timeout handling for image loading (10 second timeout)
+- Improved fallback texture creation when image loading fails
+- Added better error messages to identify the exact failure point
+
+### 3. **Tertiary Issue: References API Response Format**
+The references API was returning an object, but the code expected an array, causing `references.map is not a function` error.
+
+**Solution:**
+- Modified `fetchReferences` to handle both array and object response formats
+- Extract the references array from response data regardless of format
+
+## Changes Made
+
+### `/workspace/static/js/dicom-viewer-professional.js`
+
+1. **Added `context2d` property to `DicomRenderer` class:**
+   ```javascript
+   constructor() {
+       this.canvas = null;
+       this.context = null;
+       this.context2d = null;  // NEW
+       this.webglSupported = false;
+   }
+   ```
+
+2. **Modified `init()` to create separate 2D context:**
+   - When WebGL is supported, create a hidden 2D canvas for fallback
+   - Store both WebGL context in `this.context` and 2D context in `this.context2d`
+
+3. **Enhanced `renderWebGL()` with better validation:**
+   - Added double-check for texture validity before binding
+   - Added better error logging
+   - Improved cleanup on error
+
+4. **Enhanced `createTexture()` with comprehensive error handling:**
+   - Added detailed logging at each step
+   - Added 10-second timeout for image loading
+   - Improved fallback texture creation
+   - Better cleanup on failure
+
+5. **Modified `render2D()` to use correct context:**
+   - Changed to use `this.context2d` instead of `this.context`
+   - Added copy to main canvas when using fallback canvas
+   - Added validation for context availability
+
+6. **Updated `handleResize()` to resize fallback canvas:**
+   - Also resizes the 2D fallback canvas when it exists
+   - Ensures both canvases stay in sync during window resizing
+
+### `/workspace/templates/dicom_viewer/masterpiece_viewer.html`
+
+1. **Fixed `fetchReferences()` to handle different response formats:**
+   ```javascript
+   const references = Array.isArray(data) ? data : (data.references || []);
+   displayReferences(references);
+   ```
+
+## Expected Behavior After Fix
+
+1. **WebGL Rendering (Primary Path):**
+   - Images load via WebGL for optimal performance
+   - Proper error handling if texture creation fails
+   - Detailed logging for debugging
+
+2. **2D Fallback (When WebGL Fails):**
+   - Automatically falls back to 2D rendering
+   - Uses separate 2D canvas to avoid context conflicts
+   - Copies result to main canvas for display
+   - User sees the image regardless of WebGL support
+
+3. **References Panel:**
+   - Works with both array and object API responses
+   - No more `references.map is not a function` errors
+
+## Testing Recommendations
+
+1. Refresh the page and load a study
+2. Check browser console for detailed logging:
+   - Look for "🔧 createTexture called with imageData"
+   - Look for "📥 Loading image for WebGL texture"
+   - Look for "✅ WebGL texture created successfully" or fallback messages
+3. Verify image displays correctly
+4. Check references panel loads without errors
+
+## Performance Impact
+
+- Minimal impact: The hidden 2D canvas is only used for fallback
+- When WebGL works, performance is unchanged
+- When WebGL fails, 2D fallback provides reliable rendering
+- No performance degradation from the fixes

--- a/templates/dicom_viewer/masterpiece_viewer.html
+++ b/templates/dicom_viewer/masterpiece_viewer.html
@@ -2769,8 +2769,10 @@
                 
                 if (response.ok) {
                     const data = await response.json();
-                    displayReferences(data);
-                    showToast(`Found ${data.length || 0} references`, 'success');
+                    // Handle different response formats
+                    const references = Array.isArray(data) ? data : (data.references || []);
+                    displayReferences(references);
+                    showToast(`Found ${references.length || 0} references`, 'success');
                 } else {
                     showToast('Failed to fetch references', 'error');
                 }


### PR DESCRIPTION
Fix WebGL texture binding and enable robust 2D fallback rendering to ensure DICOM images always display.

The primary issue was a context mismatch where the 2D fallback attempted to render using a WebGL context, leading to display failures. This PR introduces a dedicated 2D fallback canvas and context, along with improved WebGL error handling, correct resizing for the fallback canvas, and a fix for the references API response format.

---
<a href="https://cursor.com/background-agent?bcId=bc-1fe7b848-a7db-4812-a53c-64c2efac9fbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1fe7b848-a7db-4812-a53c-64c2efac9fbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

