### PR TITLE
Fix DICOM series loading errors

### DIFF
--- a/dicom_viewer/urls.py
+++ b/dicom_viewer/urls.py
@@ -85,9 +85,9 @@ urlpatterns += [
 
 
     # Web viewer JSON APIs
-    path('study/<int:study_id>/', views.web_study_detail, name='web_study_detail'),
-    path('series/<int:series_id>/images/', views.web_series_images, name='web_series_images'),
-    path('image/<int:image_id>/', views.web_dicom_image, name='web_dicom_image'),
+    path('web/study/<int:study_id>/', views.web_study_detail, name='web_study_detail'),
+    path('web/series/<int:series_id>/images/', views.web_series_images, name='web_series_images'),
+    path('web/image/<int:image_id>/', views.web_dicom_image, name='web_dicom_image'),
 
     # Measurements and annotations
     path('measurements/save/', views.web_save_measurement, name='web_save_measurement'),

--- a/static/js/dicom-viewer-enhanced.js
+++ b/static/js/dicom-viewer-enhanced.js
@@ -1118,7 +1118,7 @@ document.addEventListener('DOMContentLoaded', function() {
             dicomViewerEnhanced.showToast('Loading series images...', 'info');
             console.log('Loading series:', seriesId);
             
-            const response = await fetch(`/dicom-viewer/series/${seriesId}/images/`);
+            const response = await fetch(`/dicom-viewer/web/series/${seriesId}/images/`);
             const data = await response.json();
             
             console.log('Series data received:', data);
@@ -1151,7 +1151,7 @@ document.addEventListener('DOMContentLoaded', function() {
         try {
             dicomViewerEnhanced.showToast('Loading image...', 'info');
             
-            const response = await fetch(`/dicom-viewer/image/${imageId}/`);
+            const response = await fetch(`/dicom-viewer/web/image/${imageId}/`);
             const imageUrl = response.url;
             
             // Load image into canvas

--- a/static/js/dicom-viewer-professional.js
+++ b/static/js/dicom-viewer-professional.js
@@ -98,7 +98,7 @@ class ProfessionalDicomViewer {
             console.log('Loading study:', studyId);
             
             // Try the web endpoint first
-            let response = await fetch(`/dicom-viewer/study/${studyId}/`);
+            let response = await fetch(`/dicom-viewer/web/study/${studyId}/`);
             let data = await response.json();
             
             // If that fails, try API endpoint
@@ -164,7 +164,12 @@ class ProfessionalDicomViewer {
             this.showLoading('Loading series...');
             
             // Get series images from web endpoint
-            let response = await fetch(`/dicom-viewer/series/${seriesId}/images/`);
+            let response = await fetch(`/dicom-viewer/web/series/${seriesId}/images/`);
+            
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}: Failed to fetch series ${seriesId}`);
+            }
+            
             let data = await response.json();
             
             if (data.series && data.images && data.images.length > 0) {
@@ -232,7 +237,7 @@ class ProfessionalDicomViewer {
             
         } catch (error) {
             console.error('Error loading series:', error);
-            this.showToast('Failed to load series', 'error');
+            this.showToast(`Failed to load series ${seriesId}: ${error.message}`, 'error');
         } finally {
             this.hideLoading();
         }
@@ -295,7 +300,7 @@ class ProfessionalDicomViewer {
                 
                 // Final fallback: try raw endpoint
                 if (!imageData) {
-                    const rawUrl = `/dicom-viewer/image/${imageId}/`;
+                    const rawUrl = `/dicom-viewer/web/image/${imageId}/`;
                     imageData = {
                         id: imageId,
                         url: rawUrl,

--- a/staticfiles/js/dicom-loading-fix.js
+++ b/staticfiles/js/dicom-loading-fix.js
@@ -257,7 +257,7 @@ class DicomLoadingFix {
 
     getImageUrl(imageId) {
         // Try to find the image URL from various sources
-        return `/dicom-viewer/image/${imageId}/`;
+        return `/dicom-viewer/web/image/${imageId}/`;
     }
 
     handleLoadError(imageId, error) {

--- a/staticfiles/js/dicom-viewer-canvas-fix.js
+++ b/staticfiles/js/dicom-viewer-canvas-fix.js
@@ -173,7 +173,7 @@ class DicomCanvasFix {
         try {
             console.log(`Loading series ${seriesId}...`);
             
-            const response = await fetch(`/dicom-viewer/series/${seriesId}/images/`, {
+            const response = await fetch(`/dicom-viewer/web/series/${seriesId}/images/`, {
                 method: 'GET',
                 headers: {
                     'X-Requested-With': 'XMLHttpRequest',
@@ -212,7 +212,7 @@ class DicomCanvasFix {
                 return;
             }
             
-            const response = await fetch(`/dicom-viewer/image/${imageId}/`, {
+            const response = await fetch(`/dicom-viewer/web/image/${imageId}/`, {
                 method: 'GET',
                 headers: {
                     'X-Requested-With': 'XMLHttpRequest',


### PR DESCRIPTION
Fix DICOM series, study, and image loading by correcting frontend request URLs and backend Django URL patterns.

The frontend JavaScript was making requests to incorrect API endpoints (e.g., `/dicom-viewer/series/{id}/images/` instead of `/dicom-viewer/web/series/{id}/images/`). Additionally, the Django URL patterns in `dicom_viewer/urls.py` for these web APIs were also incorrectly defined, missing the `web/` prefix. This mismatch resulted in 404 errors and JSON parsing failures (receiving HTML error pages). This PR corrects both the JavaScript request paths and the Django URL definitions to ensure proper routing and data retrieval. Error handling for series loading was also enhanced.

---
<a href="https://cursor.com/background-agent?bcId=bc-64a1326f-65af-490d-8f2b-b48f8e373543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-64a1326f-65af-490d-8f2b-b48f8e373543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

