### PR TITLE
Initialize DICOM viewer components and resolve errors

### DIFF
--- a/static/js/dicom-viewer-professional.js
+++ b/static/js/dicom-viewer-professional.js
@@ -2313,9 +2313,9 @@ document.addEventListener('DOMContentLoaded', async function() {
         window.professionalViewer = new ProfessionalDicomViewer();
         
         // Export global functions for template compatibility
-        window.loadStudy = (studyId) => window.professionalViewer.loadStudy(studyId);
-        window.loadSeries = (seriesId) => window.professionalViewer.loadSeries(seriesId);
-        window.loadImage = (imageId) => window.professionalViewer.loadImage(imageId);
+        window.loadStudy = async (studyId) => await window.professionalViewer.loadStudy(studyId);
+        window.loadSeries = async (seriesId) => await window.professionalViewer.loadSeries(seriesId);
+        window.loadImage = async (imageId) => await window.professionalViewer.loadImage(imageId);
         
         window.nextImage = () => window.professionalViewer.nextImage();
         window.previousImage = () => window.professionalViewer.previousImage();

--- a/staticfiles/js/dicom-viewer-professional.js
+++ b/staticfiles/js/dicom-viewer-professional.js
@@ -2313,9 +2313,9 @@ document.addEventListener('DOMContentLoaded', async function() {
         window.professionalViewer = new ProfessionalDicomViewer();
         
         // Export global functions for template compatibility
-        window.loadStudy = (studyId) => window.professionalViewer.loadStudy(studyId);
-        window.loadSeries = (seriesId) => window.professionalViewer.loadSeries(seriesId);
-        window.loadImage = (imageId) => window.professionalViewer.loadImage(imageId);
+        window.loadStudy = async (studyId) => await window.professionalViewer.loadStudy(studyId);
+        window.loadSeries = async (seriesId) => await window.professionalViewer.loadSeries(seriesId);
+        window.loadImage = async (imageId) => await window.professionalViewer.loadImage(imageId);
         
         window.nextImage = () => window.professionalViewer.nextImage();
         window.previousImage = () => window.professionalViewer.previousImage();


### PR DESCRIPTION
Make global `loadStudy`, `loadSeries`, and `loadImage` wrapper functions `async` to resolve "await is only valid in async functions" syntax error.

The error occurred because these `window` functions were called with `await` in other parts of the code, but they were not themselves declared as `async`, leading to an invalid syntax. By marking them `async` and `await`ing their internal calls, the syntax error is resolved, and proper promise handling is ensured.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2efc559-579e-422f-9687-1e332413664b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d2efc559-579e-422f-9687-1e332413664b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

